### PR TITLE
remove loans field from REVConfig

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -176,8 +176,7 @@ contract DeployScript is Script, Sphinx {
                 baseCurrency: ETH_CURRENCY,
                 splitOperator: OPERATOR,
                 stageConfigurations: stageConfigurations,
-                loanSources: _loanSources,
-                loans: address(revnet.loans)
+                loanSources: _loanSources
             });
         }
 


### PR DESCRIPTION
REVDeployer now hardcodes the LOANS address in its constructor.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: